### PR TITLE
Update to iteration of account.inbox.all

### DIFF
--- a/ews-crack.py
+++ b/ews-crack.py
@@ -83,7 +83,7 @@ def test_single_mode(domain, username, password):
     if account is None and config is None:
         return False
 
-    next(iter(account.inbox.all()))
+    iter(account.inbox.all())
     return True
 
 


### PR DESCRIPTION
Going through the next(iter(...)) is time consuming and not needed to validate credentials. By using just the iter() function we can show we have access the inbox, meaning the credentials are valid.